### PR TITLE
chore(ci): update to wait-for-netlify-action@2.0.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@main
       - run: mkdir /tmp/artifacts
       - name: Waiting for Netlify Preview
-        uses: kamranayub/wait-for-netlify-action@2.0.0
+        uses: kamranayub/wait-for-netlify-action@2.0.3
         id: wait-for-netflify-preview
         with:
           site_name: "naughty-euclid-aa5edb"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@main
       - run: mkdir /tmp/artifacts
       - name: Waiting for Netlify Preview
-        uses: kamranayub/wait-for-netlify-action@2.0.3
+        uses: kamranayub/wait-for-netlify-action@v2.0.3
         id: wait-for-netflify-preview
         with:
           site_name: "naughty-euclid-aa5edb"


### PR DESCRIPTION
Hi! I saw your usage linked to from the Marketplace so thought I'd send you a PR as I just released 2.0.3 which fixes building on the master/production branches.